### PR TITLE
Install the "man" and "needrestart" packages

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -62,7 +62,9 @@
         - fail2ban
         - git
         - htop
+        - man
         - ncdu
+        - needrestart
         - ntp
         - python3
         - python3-dev


### PR DESCRIPTION
* man: I needed it to check the [`systemd-growfs@.service` man page](https://manpages.ubuntu.com/manpages/bionic/man8/systemd-growfs@.service.8.html)
* [needrestart](https://manpages.ubuntu.com/manpages/bionic/en/man1/needrestart.1.html): another useful tool